### PR TITLE
recognize when an intermediate class has overridden a method

### DIFF
--- a/MustOverride/MustOverride.m
+++ b/MustOverride/MustOverride.m
@@ -84,7 +84,7 @@ static NSArray *SubclassesOfClass(Class baseClass)
     for (unsigned int i = 0; i < classCount; i++)
     {
         Class cls = classes[i];
-        Class superclass = cls;
+        Class superclass = class_getSuperclass(cls);
         while (superclass)
         {
             if (superclass == baseClass)

--- a/MustOverride/MustOverride.m
+++ b/MustOverride/MustOverride.m
@@ -71,6 +71,22 @@ static BOOL ClassOverridesMethod(Class cls, SEL selector)
     return NO;
 }
 
+static BOOL ClassOrSuperclassOverridesMethod(Class base, Class cls, SEL selector)
+{
+    BOOL overrides = NO;
+    Class superclass = cls;
+    while (superclass && superclass != base)
+    {
+        overrides = ClassOverridesMethod(superclass, selector);
+        if (overrides)
+        {
+            break;
+        }
+        superclass = class_getSuperclass(superclass);
+    }
+    return overrides;
+}
+
 static NSArray *SubclassesOfClass(Class baseClass)
 {
     static Class *classes;
@@ -125,7 +141,7 @@ static void CheckOverrides(void)
 
         for (Class subclass in SubclassesOfClass(cls))
         {
-            if (!ClassOverridesMethod(isClassMethod ? object_getClass(subclass) : subclass, selector))
+            if (!ClassOrSuperclassOverridesMethod(cls, isClassMethod ? object_getClass(subclass) : subclass, selector))
             {
                 [failures addObject:[NSString stringWithFormat:@"%@ does not implement required method %c%@",
                                      subclass, isClassMethod ? '+' : '-', parts[1]]];


### PR DESCRIPTION
This makes the following code work. `Model` overrides the method indirectly by subclassing `_Model`.

I also snuck in a quick fix to `SubclassesOfClass` so it doesn't return the base class it receives as a param.

``` objective-c
@interface Base : NSObject
- (id)someMethod;
@end
@implementation Base
- (id)someMethod { SUBCLASS_MUST_OVERRIDE; return nil; }
@end

@interface _Model : Base @end
@implementation _Model
- (id)someMethod { return @42; }
@end

@interface Model : _Model @end
@implementation Model @end
```
